### PR TITLE
Update ws dependency and jasmine-core for Node 4.x compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,12 +42,13 @@
   },
   "dependencies": {
     "angular": "*",
-    "ws": "^0.7.1"
+    "ws": "^0.8.0"
   },
   "devDependencies": {
     "angular-animate": "^1.3.13",
     "browserify": "^10.2.3",
     "browserify-ngannotate": "^1.0.1",
+    "jasmine-core": "^2.3.4",
     "karma": "^0.12.31",
     "karma-chrome-launcher": "~0.1.7",
     "karma-firefox-launcher": "^0.1.4",


### PR DESCRIPTION
Update `ws` to a version that is compatible with Node 4.x
and add missing `jasmine-core` dependency that was previously
installed via npm as a peer dependency
but with npm 3.x is no longer installed automatically.

Fixes #47