### PR TITLE
Bump to 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+## 2.0.0 (2016-5-21)
+
+Features:
+  - Repackage library
+  - Package source files no longer duplicated
+
+Bugfixes:
+  - autoApply is undefined error
+  - arraybuffer data type
+
+BREAKING CHANGES:
+  - package source files are not duplicated
+    - if using files from `/`, use `/dist/` instead
+      - change `/angular-websocket-mock.js` to `/dist/angular-websocket-mock.js`
+      - change `/angular-websocket.js` to `/dist/angular-websocket.js`
+      - change `/angular-websocket-min.js` to `/dist/angular-websocket-min.js`
+      - change `/angular-websocket-min.js.map` to `/dist/angular-websocket-min.js.map`
+
+## 1.1.0 (2016-4-4)
+
+## 1.0.14 (2015-9-15)
+
 ## 1.0.13 (2015-6-2)
  Build:
   - UpdatedevDependencies

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-websocket",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "homepage": "https://github.com/gdi2290/angular-websocket",
   "description": "An AngularJS 1.x WebSocket service for connecting client applications to servers.",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-websocket",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "main": "./dist/angular-websocket.js",
   "description": "An Angular WebSocket service for connecting client applications to servers.",
   "homepage": "https://github.com/angular-class/angular-websocket",


### PR DESCRIPTION
Repo repackaged https://github.com/AngularClass/angular-websocket/pull/75

Closes https://github.com/AngularClass/angular-websocket/issues/72

Also needs an npm release by `angularclass` or `gdi2290` and a tag