### PR TITLE
Updating URLs with latest release

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ You can download angular-websocket by:
 
 * (prefered) Using bower and running `bower install angular-websocket --save`
 * Using npm and running `npm install angular-websocket --save`
-* Downloading it manually by clicking [here to download development unminified version](https://raw.github.com/gdi2290/angular-websocket/master/angular-websocket.js)
-* CDN for development `https://rawgit.com/gdi2290/angular-websocket/v1.0.9/angular-websocket.js`
-* CDN for production `https://cdn.rawgit.com/gdi2290/angular-websocket/v1.0.9/angular-websocket.min.js`
+* Downloading it manually by clicking [here to download development unminified version](https://raw.github.com/AngularClass/angular-websocket/master/dist/angular-websocket.js)
+* CDN for development `https://cdn.rawgit.com/AngularClass/angular-websocket/v2.0.0/dist/angular-websocket.js`
+* CDN for production `https://cdn.rawgit.com/AngularClass/angular-websocket/v2.0.0/dist/angular-websocket.min.js`
 
 ## Usage
 


### PR DESCRIPTION
Files were moved to "/dist" in v2.0.0, so updating version number in old URLs no longer worked.